### PR TITLE
Add Flag to enable skipping of unknown AST parts

### DIFF
--- a/cmd/kelon/kelon.go
+++ b/cmd/kelon/kelon.go
@@ -48,6 +48,7 @@ var (
 	port                  = app.Flag("port", "Port on which the proxy endpoint is served.").Short('p').Default("8181").Envar("PORT").Uint32()
 	preprocessRegos       = app.Flag("preprocess-policies", "Preprocess incoming policies for internal use-case (EXPERIMENTAL FEATURE! DO NOT USE!).").Default("false").Envar("PREPROCESS_POLICIES").Bool()
 	respondWithStatusCode = app.Flag("respond-with-status-code", "Communicate Decision via status code 200 (ALLOW) or 403 (DENY).").Default("false").Envar("RESPOND_WITH_STATUS_CODE").Bool()
+	astSkipUnknown        = app.Flag("ast-skip-unknown", "Skip unknown parts in the AST and only log as warning.").Default("false").Envar("AST_SKIP_UNKNOWN").Bool()
 
 	// Logging
 	logLevel               = app.Flag("log-level", "Log-Level for Kelon. Must be one of [DEBUG, INFO, WARN, ERROR]").Default("INFO").Envar("LOG_LEVEL").Enum("DEBUG", "INFO", "WARN", "ERROR", "debug", "info", "warn", "error")
@@ -231,7 +232,8 @@ func makeServerConfig(compiler opa.PolicyCompiler, parser request.PathProcessor,
 			},
 			Translator: &translator,
 			AstTranslatorConfig: translate.AstTranslatorConfig{
-				Datastores: data.MakeDatastores(loadedConf.Data),
+				Datastores:  data.MakeDatastores(loadedConf.Data),
+				SkipUnknown: *astSkipUnknown,
 			},
 			AccessDecisionLogLevel: strings.ToUpper(*accessDecisionLogLevel),
 		},

--- a/internal/pkg/translate/default-processor.go
+++ b/internal/pkg/translate/default-processor.go
@@ -19,10 +19,11 @@ type astProcessor struct {
 	relations    []data.Node
 	operands     NodeStack
 	errors       []string
+	skipUnknown  bool
 }
 
-func newAstProcessor() *astProcessor {
-	return &astProcessor{}
+func newAstProcessor(skipUnknown bool) *astProcessor {
+	return &astProcessor{skipUnknown: skipUnknown}
 }
 
 // See translate.AstTranslator.
@@ -84,7 +85,11 @@ func (p *astProcessor) Visit(v interface{}) ast.Visitor {
 		logging.LogForComponent("astProcessor").Debugf("Term: -> %+v", v)
 		return p.translateTerm(*node)
 	default:
-		p.errors = append(p.errors, fmt.Sprintf("Unexpectedly visiting children of: %T -> %+v", v, v))
+		if p.skipUnknown {
+			logging.LogForComponent("astProcessor").Warnf("Unexpectedly visiting children of: %T -> %+v", v, v)
+		} else {
+			p.errors = append(p.errors, fmt.Sprintf("Unexpectedly visiting children of: %T -> %+v", v, v))
+		}
 	}
 	return p
 }
@@ -173,7 +178,11 @@ func (p *astProcessor) translateTerm(node ast.Term) ast.Visitor {
 		})
 		return nil
 	default:
-		p.errors = append(p.errors, fmt.Sprintf("Unexpected term Node: %T -> %+v", v, v))
+		if p.skipUnknown {
+			logging.LogForComponent("astProcessor").Warnf("Unexpected term Node: %T -> %+v", v, v)
+		} else {
+			p.errors = append(p.errors, fmt.Sprintf("Unexpected term Node: %T -> %+v", v, v))
+		}
 	}
 	return p
 }

--- a/internal/pkg/translate/default-translator.go
+++ b/internal/pkg/translate/default-translator.go
@@ -62,7 +62,7 @@ func (trans astTranslator) Process(response *rego.PartialQueries, datastore stri
 		return false, errors.Wrap(preprocessErr, "AstTranslator: Error during preprocessing.")
 	}
 
-	processedQuery, processErr := newAstProcessor().Process(preprocessedQueries)
+	processedQuery, processErr := newAstProcessor(trans.config.SkipUnknown).Process(preprocessedQueries)
 	if processErr != nil {
 		return false, processErr
 	}

--- a/pkg/translate/ast-translator.go
+++ b/pkg/translate/ast-translator.go
@@ -16,7 +16,8 @@ import (
 // instance of a AstTranslator can be seen as a standalone thread with all its subcomponents attached to it.
 // As a result, two AstTranslators should be able to run in parallel.
 type AstTranslatorConfig struct {
-	Datastores map[string]*data.DatastoreTranslator
+	Datastores  map[string]*data.DatastoreTranslator
+	SkipUnknown bool
 }
 
 // AstTranslator is the interface that maps a partially evaluated AST returned by OPA to a final decision (Allow/Deny).


### PR DESCRIPTION
Introduction of `ast-skip-unknown` flag
If set, unknown parts of the AST are logged as warnings instead of throwing error and denying request