### PR TITLE
Support for Traefiks ForwardAuth Middleware

### DIFF
--- a/internal/pkg/api/rest-handler.go
+++ b/internal/pkg/api/rest-handler.go
@@ -103,6 +103,36 @@ func (proxy *restProxy) handleV1DataPost(w http.ResponseWriter, r *http.Request)
 	}
 }
 
+func (proxy *restProxy) handleV1DataForwardAuth(w http.ResponseWriter, r *http.Request) {
+	// Build input body from traefik's forward auth request
+	path := r.Header.Get(constants.HeaderXForwardedURI)
+	method := r.Header.Get(constants.HeaderXForwardedMethod)
+
+	inputBody := map[string]map[string]interface{}{
+		"input": {
+			"method": method,
+			"path":   path,
+		}}
+
+	if r.Header.Get(constants.HeaderAuthorization) != "" {
+		inputBody["input"]["token"] = r.Header.Get(constants.HeaderAuthorization)
+	}
+
+	body, err := json.Marshal(inputBody)
+	if err != nil {
+		proxy.handleError(r.Context(), w, wrapErrorInLoggingContext(err))
+		return
+	}
+
+	endpointData := proxy.pathPrefix + constants.EndpointSuffixData
+	if trans, err := http.NewRequest("POST", endpointData, bytes.NewReader(body)); err == nil {
+		// Handle request like post
+		proxy.handleV1DataPost(w, trans)
+	} else {
+		logging.LogForComponent("restProxy").Fatal("Unable to map GET request to POST: ", err.Error())
+	}
+}
+
 // Migration from github.com/open-policy-agent/opa/server/server.go
 func (proxy *restProxy) handleV1DataPut(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()

--- a/pkg/constants/request.go
+++ b/pkg/constants/request.go
@@ -5,3 +5,14 @@ type ContextKey string
 // ContextKeyRequestID is the ContextKey for RequestID
 const ContextKeyRequestID = ContextKey("requestUID") // can be unexported
 const ContextKeyRegoPackage = ContextKey("regoPackage")
+
+const HeaderXForwardedMethod = "X-Forwarded-Method"
+const HeaderXForwardedURI = "X-Forwarded-URI"
+const HeaderAuthorization = "Authorization"
+
+const EndpointSuffixData = "/data"
+const EndpointSuffixForwardAuth = "/forward-auth"
+const EndpointSuffixPolicies = "/policies"
+
+const EndpointHealth = "/health"
+const EndpointMetrics = "/metrics"

--- a/test/e2e/parseObjects.go
+++ b/test/e2e/parseObjects.go
@@ -1,8 +1,16 @@
 package e2e
 
 type Request struct {
-	Name       string `yaml:"name"`
-	URL        string `yaml:"url"`
-	Body       string `yaml:"body"`
-	StatusCode int    `yaml:"statusCode"`
+	Name       string            `yaml:"name"`
+	Method     string            `yaml:"method"`
+	URL        string            `yaml:"url"`
+	Body       string            `yaml:"body"`
+	StatusCode int               `yaml:"statusCode"`
+	Headers    map[string]string `yaml:"header"`
+}
+
+func (r *Request) Defaults() {
+	if r.Method == "" {
+		r.Method = "POST"
+	}
 }

--- a/test/e2e/test_config/requests.yml
+++ b/test/e2e/test_config/requests.yml
@@ -157,3 +157,12 @@
   url: "http://%s:%s/v1/data"
   body: '{ "input": { "method": "GET", "path": "/api/pure/apps/2", "user": "Nobody", "password": "pw_nobody" } }'
   statusCode: 403
+
+
+- name: "ForwardAuth: Pure - First App visible for everyone"
+  method: "GET"
+  url: "http://%s:%s/v1/forward-auth"
+  header:
+    X-Forwarded-Method: "GET"
+    X-Forwarded-URI: "/api/pure/apps/1"
+  statusCode: 200


### PR DESCRIPTION
Introduce new Endpoint `$pathPrefix/forward-auth` which transforms a GET into a POST `$pathPrefix/data`with body 
```json
{"input": {"method": "$X-Forwarded-Method", "path":"$X-Forwarded-Uri"}}
```