### PR TITLE
map request header into policy input

### DIFF
--- a/configs/config.go
+++ b/configs/config.go
@@ -19,6 +19,7 @@ type AppConfig struct {
 
 // ExternalConfig holds all externally configurable properties
 type ExternalConfig struct {
+	Global           Global                              `yaml:"global"`
 	APIMappings      []*DatastoreAPIMapping              `yaml:"apis"`
 	Datastores       map[string]*Datastore               `yaml:"datastores"`
 	DatastoreSchemas map[string]map[string]*EntitySchema `yaml:"entity_schemas"`
@@ -36,6 +37,10 @@ func (ec *ExternalConfig) Defaults() {
 }
 
 func (ec *ExternalConfig) Validate() error {
+	if err := ec.Global.Validate(); err != nil {
+		return errors.Wrap(err, "loaded invalid configuration")
+	}
+
 	for _, mapping := range ec.APIMappings {
 		if err := mapping.Validate(ec.DatastoreSchemas); err != nil {
 			return errors.Wrap(err, "loaded invalid configuration")

--- a/configs/config_test.go
+++ b/configs/config_test.go
@@ -9,6 +9,20 @@ import (
 
 //nolint:gochecknoglobals,gocritic
 var wantedExternalConfig = configs.ExternalConfig{
+	Global: configs.Global{
+		Input: configs.Input{
+			HeaderMapping: []*configs.HeaderMapping{
+				{
+					Name:  "Foo",
+					Alias: "Foo",
+				},
+				{
+					Name:  "Bar",
+					Alias: "Baz",
+				},
+			},
+		},
+	},
 	APIMappings: []*configs.DatastoreAPIMapping{
 		{
 			Prefix:         "/api",

--- a/configs/global.go
+++ b/configs/global.go
@@ -1,0 +1,47 @@
+package configs
+
+import "github.com/pkg/errors"
+
+// Global holds the global configuration for the application.
+type Global struct {
+	Input Input `yaml:"input"`
+}
+
+// Input holds input related configuration, such as global header to input mappings.
+type Input struct {
+	HeaderMapping []*HeaderMapping `yaml:"header-mapping"`
+}
+
+// HeaderMapping is a simple struct to hold a key-value pair for headers that should be included in the request.
+// If Name is not set, the header will be included as is, otherwise the header will be included as the specified name.
+type HeaderMapping struct {
+	Name  string `yaml:"name"`
+	Alias string `yaml:"alias"`
+}
+
+func (g *Global) Validate() error {
+	return g.Input.Validate()
+}
+
+func (i *Input) Validate() error {
+	// Validate include header mappings
+	headerCache := make(map[string]struct{})
+	for _, header := range i.HeaderMapping {
+		if header.Name == "" {
+			return errors.Errorf("Empty header in include-header")
+		}
+
+		// If no target name is set, use the header as is
+		if header.Alias == "" {
+			header.Alias = header.Name
+		}
+
+		// check for duplicates
+		if _, ok := headerCache[header.Name]; ok {
+			return errors.Errorf("Duplicate header alias %q in include-header", header.Alias)
+		}
+		headerCache[header.Alias] = struct{}{}
+	}
+
+	return nil
+}

--- a/configs/testdata/valid.yml
+++ b/configs/testdata/valid.yml
@@ -1,3 +1,10 @@
+global:
+  input:
+    header-mapping:
+      - name: Foo
+      - name: Bar
+        alias: Baz
+
 apis:
   # All api-mappings for datastore postgres
   - path-prefix: /api

--- a/examples/docker-compose/config/kelon.yml
+++ b/examples/docker-compose/config/kelon.yml
@@ -1,3 +1,12 @@
+global:
+  input:
+    header-mapping:
+      - name: X-Forwarded-Method
+        alias: method
+      - name: X-Forwarded-URI
+        alias: path
+      - name: Foo
+
 apis:
   # Route all requests starting with /api/mysql to mysql database
   - path-prefix: /api/mysql
@@ -26,6 +35,8 @@ apis:
     authentication: false
     mappings:
       - path: /apps/.*
+        package: applications.pure
+      - path: /header.*
         package: applications.pure
   # Route all requests starting with /api/mixed to MongoDB and Postgres
   - path-prefix: /api/mixed
@@ -125,6 +136,7 @@ entity_schemas:
               entities:
                 - name: user
                   alias: users
+
 
 opa:
   labels:

--- a/examples/docker-compose/policies/pure_example.rego
+++ b/examples/docker-compose/policies/pure_example.rego
@@ -15,3 +15,11 @@ allow {
 allow {
 	input.user == "Torben"
 }
+
+# Path: GET /api/pure/header
+# Foo header must be set to bar
+allow {
+	input.method == "GET"
+	input.path == ["api", "pure", "header"]
+	input.Foo == "bar"
+}

--- a/internal/pkg/api/rest-handler.go
+++ b/internal/pkg/api/rest-handler.go
@@ -139,7 +139,7 @@ func (proxy *restProxy) handleV1DataPut(w http.ResponseWriter, r *http.Request) 
 	} else if r.Header.Get("If-None-Match") == "*" {
 		engine.Store.Abort(ctx, txn)
 		logging.LogForComponent("restProxy").Infof("Update data with If-None-Match header at path: %s", path.String())
-		writer.Bytes(w, 304, nil)
+		w.WriteHeader(http.StatusNotModified)
 		return
 	}
 
@@ -232,7 +232,7 @@ func (proxy *restProxy) handleV1DataDelete(w http.ResponseWriter, r *http.Reques
 
 	// Write result
 	logging.LogForComponent("restProxy").Infof("Deleted Data at path: %s", path.String())
-	writer.Bytes(w, 204, nil)
+	w.WriteHeader(http.StatusNoContent)
 }
 
 /*
@@ -508,7 +508,7 @@ func (proxy *restProxy) checkPathConflictsCommitAndRespond(ctx context.Context, 
 	}
 	// Write result
 	logging.LogForComponent("restProxy").Infof("Created Data at path: %s", path.String())
-	writer.Bytes(w, 204, nil)
+	w.WriteHeader(http.StatusNoContent)
 }
 
 // Migration from github.com/open-policy-agent/opa/server/server.go

--- a/internal/pkg/api/rest-handler.go
+++ b/internal/pkg/api/rest-handler.go
@@ -68,7 +68,12 @@ func (proxy *restProxy) handleV1DataGet(w http.ResponseWriter, r *http.Request) 
 		logging.LogForComponent("restProxy").Warnln("Received GET request without input: " + r.URL.String())
 	}
 
-	if trans, err := http.NewRequest("POST", r.URL.String(), strings.NewReader(body)); err == nil {
+	builder := strings.Builder{}
+	builder.WriteString(`{"input":`)
+	builder.WriteString(body)
+	builder.WriteRune('}')
+
+	if trans, err := http.NewRequest("POST", r.URL.String(), strings.NewReader(builder.String())); err == nil {
 		// Handle request like post
 		proxy.handleV1DataPost(w, trans)
 	} else {
@@ -109,13 +114,13 @@ func (proxy *restProxy) handleV1DataForwardAuth(w http.ResponseWriter, r *http.R
 	method := r.Header.Get(constants.HeaderXForwardedMethod)
 
 	inputBody := map[string]map[string]interface{}{
-		"input": {
+		constants.Input: {
 			"method": method,
 			"path":   path,
 		}}
 
 	if r.Header.Get(constants.HeaderAuthorization) != "" {
-		inputBody["input"]["token"] = r.Header.Get(constants.HeaderAuthorization)
+		inputBody[constants.Input]["token"] = r.Header.Get(constants.HeaderAuthorization)
 	}
 
 	body, err := json.Marshal(inputBody)

--- a/internal/pkg/api/rest-middleware.go
+++ b/internal/pkg/api/rest-middleware.go
@@ -1,0 +1,135 @@
+package api
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+
+	"github.com/pkg/errors"
+	"github.com/unbasical/kelon/pkg/constants"
+	"github.com/unbasical/kelon/pkg/constants/logging"
+)
+
+func (proxy *restProxy) applyHandlerMiddlewareIfSet(ctx context.Context, handlerFunc func(http.ResponseWriter, *http.Request), endpoint string) http.Handler {
+	var wrappedHandler http.Handler = http.HandlerFunc(handlerFunc)
+
+	wrappedHandler = proxy.inputHeaderMappingMiddleware(wrappedHandler)
+	wrappedHandler = proxy.appConf.MetricsProvider.WrapHTTPHandler(ctx, wrappedHandler)
+	wrappedHandler = proxy.appConf.TraceProvider.WrapHTTPHandler(ctx, wrappedHandler, endpoint)
+
+	return wrappedHandler
+}
+
+func (proxy *restProxy) inputHeaderMappingMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]interface{}
+		var err error
+
+		if r.Method == http.MethodGet {
+			// Get the input from query for GET requests
+			body, err = extractInputFromQuery(r)
+		} else {
+			// Get from request body for all other requests
+			body, err = extractInputFromBody(r)
+		}
+		if err != nil {
+			logging.LogForComponent("restProxy").Errorf("Unable to extract input: %s", err.Error())
+			http.Error(w, "Unable to extract input", http.StatusBadRequest)
+			return
+		}
+
+		// Enrich input with header mappings
+		enriched, err := proxy.applyHeaderMappingsToInput(body, r)
+		if err != nil {
+			logging.LogForComponent("restProxy").Errorf("Unable to enrich input: %s", err.Error())
+			http.Error(w, "Unable to enrich input", http.StatusInternalServerError)
+			return
+		}
+
+		// Write back to request
+		if r.Method == http.MethodGet {
+			err = writeInputToQuery(r, enriched)
+		} else {
+			err = writeInputToBody(r, enriched)
+		}
+		if err != nil {
+			logging.LogForComponent("restProxy").Errorf("Unable to write input: %s", err.Error())
+			http.Error(w, "Unable to write input", http.StatusInternalServerError)
+			return
+		}
+
+		// Add header mapping here
+		next.ServeHTTP(w, r)
+	})
+}
+
+func extractInputFromQuery(r *http.Request) (map[string]interface{}, error) {
+	body := map[string]interface{}{constants.Input: make(map[string]interface{})}
+	query := r.URL.Query()
+	if keys, ok := query[constants.Input]; ok && len(keys) == 1 {
+		// Assign body
+		var value map[string]interface{}
+		if err := json.Unmarshal([]byte(keys[0]), &value); err != nil {
+			return nil, errors.Wrapf(err, "Unable to parse input")
+		}
+		body[constants.Input] = value
+	}
+	return body, nil
+}
+
+func extractInputFromBody(r *http.Request) (map[string]interface{}, error) {
+	var body map[string]interface{}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		return nil, errors.Wrap(err, "Unable to parse input")
+	}
+
+	return body, nil
+}
+
+func writeInputToQuery(r *http.Request, body map[string]interface{}) error {
+	value, err := json.Marshal(body[constants.Input])
+	if err != nil {
+		return errors.Wrap(err, "Unable to marshal input")
+	}
+
+	query := r.URL.Query()
+	query.Set(constants.Input, string(value))
+	r.URL.RawQuery = query.Encode()
+
+	return nil
+}
+
+func writeInputToBody(r *http.Request, body map[string]interface{}) error {
+	enrichedMarshalled, err := json.Marshal(body)
+	if err != nil {
+		return errors.Wrap(err, "Unable to marshal input")
+	}
+
+	r.Body = io.NopCloser(bytes.NewBuffer(enrichedMarshalled))
+	return nil
+}
+
+// applyHeaderMappingsToInput inserts the Header (specified by the config) into the input
+func (proxy *restProxy) applyHeaderMappingsToInput(body map[string]interface{}, r *http.Request) (map[string]interface{}, error) {
+	var input map[string]interface{}
+	value, ok := body[constants.Input]
+	if !ok {
+		// No input provided, create empty input
+		input = make(map[string]interface{})
+	} else if input, ok = value.(map[string]interface{}); !ok {
+		return nil, errors.Errorf("Mismatched type for body[%s]. Expected %T but got %T", constants.Input, input, value)
+	}
+
+	for _, mapping := range proxy.appConf.Global.Input.HeaderMapping {
+		headerValue := r.Header.Get(mapping.Name)
+		if headerValue == "" {
+			continue
+		}
+		input[mapping.Alias] = headerValue
+	}
+
+	body[constants.Input] = input
+	return body, nil
+}

--- a/internal/pkg/api/rest-proxy.go
+++ b/internal/pkg/api/rest-proxy.go
@@ -17,7 +17,7 @@ import (
 
 type restProxy struct {
 	pathPrefix string
-	port       int32
+	port       uint32
 	configured bool
 	appConf    *configs.AppConfig
 	config     *api.ClientProxyConfig
@@ -28,7 +28,7 @@ type restProxy struct {
 }
 
 // Implements api.ClientProxy by providing OPA's Data-REST-API.
-func NewRestProxy(pathPrefix string, port int32) api.ClientProxy {
+func NewRestProxy(pathPrefix string, port uint32) api.ClientProxy {
 	return &restProxy{
 		pathPrefix: pathPrefix,
 		port:       port,
@@ -40,7 +40,7 @@ func NewRestProxy(pathPrefix string, port int32) api.ClientProxy {
 }
 
 // See Configure() of api.ClientProxy
-func (proxy *restProxy) Configure(ctx context.Context, appConf *configs.AppConfig, serverConf *api.ClientProxyConfig) error {
+func (proxy *restProxy) Configure(_ context.Context, appConf *configs.AppConfig, serverConf *api.ClientProxyConfig) error {
 	// Exit if already configured
 	if proxy.configured {
 		return nil

--- a/internal/pkg/api/rest-proxy.go
+++ b/internal/pkg/api/rest-proxy.go
@@ -80,13 +80,11 @@ func (proxy *restProxy) Start() error {
 	ctx := context.Background()
 
 	endpointData := proxy.pathPrefix + constants.EndpointSuffixData
-	endpointForwardAuth := proxy.pathPrefix + constants.EndpointSuffixForwardAuth
 	endpointPolicies := proxy.pathPrefix + constants.EndpointSuffixPolicies
 
 	// Endpoints to validate queries
 	proxy.router.PathPrefix(endpointData).Handler(proxy.applyHandlerMiddlewareIfSet(ctx, proxy.handleV1DataGet, endpointData)).Methods("GET")
 	proxy.router.PathPrefix(endpointData).Handler(proxy.applyHandlerMiddlewareIfSet(ctx, proxy.handleV1DataPost, endpointData)).Methods("POST")
-	proxy.router.PathPrefix(endpointForwardAuth).Handler(proxy.applyHandlerMiddlewareIfSet(ctx, proxy.handleV1DataForwardAuth, endpointForwardAuth)).Methods("GET")
 
 	// Endpoints to update policies and data
 	proxy.router.PathPrefix(endpointData).Handler(proxy.applyHandlerMiddlewareIfSet(ctx, proxy.handleV1DataPut, endpointData)).Methods("PUT")
@@ -119,16 +117,6 @@ func (proxy *restProxy) Start() error {
 		}
 	}()
 	return nil
-}
-
-func (proxy *restProxy) applyHandlerMiddlewareIfSet(ctx context.Context, handlerFunc func(http.ResponseWriter, *http.Request), endpoint string) http.Handler {
-	var wrappedHandler http.Handler = http.HandlerFunc(handlerFunc)
-
-	wrappedHandler = proxy.appConf.MetricsProvider.WrapHTTPHandler(ctx, wrappedHandler)
-
-	wrappedHandler = proxy.appConf.TraceProvider.WrapHTTPHandler(ctx, wrappedHandler, endpoint)
-
-	return wrappedHandler
 }
 
 // See Stop() of api.ClientProxy

--- a/internal/pkg/core/kelon.go
+++ b/internal/pkg/core/kelon.go
@@ -204,7 +204,7 @@ func (k *Kelon) loadCallOperands(appConfig *configs.AppConfig) {
 
 func (k *Kelon) startNewRestProxy(ctx context.Context, appConfig *configs.AppConfig, serverConf *api.ClientProxyConfig) {
 	// Create Rest proxy and start
-	k.proxy = apiInt.NewRestProxy(*k.config.PathPrefix, int32(*k.config.Port))
+	k.proxy = apiInt.NewRestProxy(*k.config.PathPrefix, *k.config.Port)
 	if err := k.proxy.Configure(ctx, appConfig, serverConf); err != nil {
 		k.logger.Fatalln(err.Error())
 	}

--- a/internal/pkg/core/kelon.go
+++ b/internal/pkg/core/kelon.go
@@ -125,6 +125,7 @@ func (k *Kelon) onConfigLoaded(change watcher.ChangeType, loadedConf *configs.Ex
 		)
 
 		// Build config
+		config.Global = loadedConf.Global
 		config.APIMappings = loadedConf.APIMappings
 		config.DatastoreSchemas = loadedConf.DatastoreSchemas
 		config.Datastores = loadedConf.Datastores

--- a/internal/pkg/data/operands.go
+++ b/internal/pkg/data/operands.go
@@ -160,7 +160,7 @@ func loadDatastoreCallOpsBytes(input []byte, dsFunctions map[string]int) ([]data
 	loadedConf := callHandlers{}
 	// Load call operands
 	if err := yaml.Unmarshal(input, &loadedConf); err != nil {
-		return nil, errors.Errorf("GenericCallOpMapper: Unable to parse datastore call-operands config: " + err.Error())
+		return nil, errors.Wrap(err, "unable to parse datastore call-operands config")
 	}
 
 	result := make([]data.CallOpMapper, len(loadedConf.CallOperands))

--- a/internal/pkg/opa/default-compiler.go
+++ b/internal/pkg/opa/default-compiler.go
@@ -75,6 +75,11 @@ func (compiler *policyCompiler) Configure(appConf *configs.AppConfig, compConf *
 	return nil
 }
 
+// Execute expects a map with the following structure:
+//
+// - input
+//   - method: match policy on HTTP method
+//   - path: match policy on HTTP path
 func (compiler policyCompiler) Execute(ctx context.Context, requestBody map[string]interface{}) (*opa.Decision, error) {
 	// Validate if policy compiler was configured correctly
 	if !compiler.configured {
@@ -88,7 +93,7 @@ func (compiler policyCompiler) Execute(ctx context.Context, requestBody map[stri
 		}
 	}
 
-	rawInput, exists := requestBody["input"]
+	rawInput, exists := requestBody[constants.Input]
 	if !exists {
 		return nil, internalErrors.InvalidInput{Msg: "PolicyCompiler: Incoming requestBody had no field 'input'!"}
 	}

--- a/internal/pkg/request/url-mapper.go
+++ b/internal/pkg/request/url-mapper.go
@@ -78,7 +78,7 @@ func (mapper pathMapper) Map(input interface{}) (*request.MapperOutput, error) {
 		}
 		return mapper.handleInput(in)
 	default:
-		return nil, errors.Errorf("PathMapper: Input of Process() was not of type *request.pathMapperInput! Type was: " + reflect.TypeOf(input).String())
+		return nil, errors.Errorf("pathMapper: Input of Process() was not of type *request.pathMapperInput! Type was: %s", reflect.TypeOf(input).String())
 	}
 }
 
@@ -128,7 +128,7 @@ func (mapper *pathMapper) generateMappings() error {
 		for _, mapping := range dsMapping.Mappings {
 			endpointsRegex := "[(GET)|(POST)|(PUT)|(DELETE)|(PATCH)]"
 			endpointsCount := 0
-			if mapping.Methods != nil && len(mapping.Methods) > 0 {
+			if len(mapping.Methods) > 0 {
 				endpointsCount = len(mapping.Methods)
 				anchoredMappings := make([]string, endpointsCount)
 				for i, method := range mapping.Methods {
@@ -139,7 +139,7 @@ func (mapper *pathMapper) generateMappings() error {
 
 			queriesRegex := ""
 			queriesCount := 0
-			if mapping.Queries != nil && len(mapping.Queries) > 0 {
+			if len(mapping.Queries) > 0 {
 				queriesRegex = fmt.Sprintf("?%s=.*?", strings.Join(mapping.Queries, "=.*?"))
 				queriesCount = len(mapping.Queries)
 			}

--- a/internal/pkg/request/url-processor.go
+++ b/internal/pkg/request/url-processor.go
@@ -69,7 +69,7 @@ func (processor urlProcessor) Process(input interface{}) (*request.PathProcessor
 	case *URLProcessorInput:
 		return processor.handleInput(in)
 	default:
-		return nil, errors.Errorf("UrlProcessor: Input of Process() was not of type *request.URLProcessorInput! Type was: " + reflect.TypeOf(input).String())
+		return nil, errors.Errorf("urlProcessor: Input of Process() was not of type *request.URLProcessorInput! Type was: %s", reflect.TypeOf(input).String())
 	}
 }
 

--- a/internal/pkg/util/stacks.go
+++ b/internal/pkg/util/stacks.go
@@ -77,3 +77,10 @@ func AppendToTop[T any](s *Stack[[]T], v T) error {
 	logging.LogForComponent("Stack").Debugf("%30sStack len(%d) APPEND |%+v <- TOP", "", s.Size(), s.values[s.Size()-1])
 	return nil
 }
+
+func AppendToTopChecked[T any](component string, s *Stack[[]T], v T) {
+	err := AppendToTop(s, v)
+	if err != nil {
+		logging.LogForComponent(component).Panicf("Error appending to top: %s", err)
+	}
+}

--- a/pkg/constants/request.go
+++ b/pkg/constants/request.go
@@ -6,12 +6,13 @@ type ContextKey string
 const ContextKeyRequestID = ContextKey("requestUID") // can be unexported
 const ContextKeyRegoPackage = ContextKey("regoPackage")
 
+const Input = "input"
+
 const HeaderXForwardedMethod = "X-Forwarded-Method"
 const HeaderXForwardedURI = "X-Forwarded-URI"
 const HeaderAuthorization = "Authorization"
 
 const EndpointSuffixData = "/data"
-const EndpointSuffixForwardAuth = "/forward-auth"
 const EndpointSuffixPolicies = "/policies"
 
 const EndpointHealth = "/health"

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -274,7 +274,7 @@ func configureExposablePorts(t *testing.T, config *testConfiguration) {
 	for serivce, ds := range data.Datastores {
 		id, idErr := serviceFromString(serivce)
 		if idErr != nil {
-			t.Errorf("error extracting ports from config: %s", err.Error())
+			t.Errorf("error extracting ports from config: %s", idErr.Error())
 			t.FailNow()
 		}
 

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -98,32 +98,34 @@ func NewTest(ctx context.Context, t *testing.T, name string, config *testConfigu
 
 func (env *E2ETestEnvironment) runTests() {
 	for _, request := range env.requests {
-		url := fmt.Sprintf(request.URL, "localhost", strconv.Itoa(int(env.kelonPort)))
+		env.t.Run(request.Name, func(t *testing.T) {
+			url := fmt.Sprintf(request.URL, "localhost", strconv.Itoa(int(env.kelonPort)))
 
-		//nolint:gosec,gocritic
-		req, reqErr := http.NewRequest(strings.ToUpper(request.Method), url, bytes.NewBufferString(request.Body))
-		if reqErr != nil {
-			env.t.Errorf("%s: %s - %s", request.Name, url, reqErr.Error())
-			env.t.FailNow()
-		}
+			//nolint:gosec,gocritic
+			req, reqErr := http.NewRequest(strings.ToUpper(request.Method), url, bytes.NewBufferString(request.Body))
+			if reqErr != nil {
+				env.t.Errorf("%s: %s - %s", request.Name, url, reqErr.Error())
+				env.t.FailNow()
+			}
 
-		req.Header.Set("Content-Type", "application/json")
+			req.Header.Set("Content-Type", "application/json")
 
-		for k, v := range request.Headers {
-			req.Header.Set(k, v)
-		}
+			for k, v := range request.Headers {
+				req.Header.Set(k, v)
+			}
 
-		resp, httpErr := http.DefaultClient.Do(req)
-		if httpErr != nil {
-			env.t.Errorf("%s: %s - %s", request.Name, url, httpErr.Error())
-			env.t.FailNow()
-		}
+			resp, httpErr := http.DefaultClient.Do(req)
+			if httpErr != nil {
+				env.t.Errorf("%s: %s - %s", request.Name, url, httpErr.Error())
+				env.t.FailNow()
+			}
 
-		_ = resp.Body.Close()
+			_ = resp.Body.Close()
 
-		fmt.Printf("Name: %s - Expect: %d - Got: %d\n", request.Name, request.StatusCode, resp.StatusCode)
+			fmt.Printf("Name: %s - Expect: %d - Got: %d\n", request.Name, request.StatusCode, resp.StatusCode)
 
-		assert.Equal(env.t, request.StatusCode, resp.StatusCode, "%s: asserting response status code", request.Name)
+			assert.Equal(env.t, request.StatusCode, resp.StatusCode, "%s: asserting response status code", request.Name)
+		})
 	}
 }
 

--- a/test/e2e/test_config/requests.yml
+++ b/test/e2e/test_config/requests.yml
@@ -158,11 +158,24 @@
   body: '{ "input": { "method": "GET", "path": "/api/pure/apps/2", "user": "Nobody", "password": "pw_nobody" } }'
   statusCode: 403
 
-
 - name: "ForwardAuth: Pure - First App visible for everyone"
   method: "GET"
-  url: "http://%s:%s/v1/forward-auth"
+  url: "http://%s:%s/v1/data"
   header:
     X-Forwarded-Method: "GET"
     X-Forwarded-URI: "/api/pure/apps/1"
+  statusCode: 200
+
+- name: "Header Inclusion: GET Query - Pure - Foo header should not be aliased"
+  method: "GET"
+  url: 'http://%s:%s/v1/data?input=%%7B%%22method%%22%%3A%%22GET%%22%%2C%%22path%%22%%3A%%22%%2Fapi%%2Fpure%%2Fheader%%22%%7D'
+  header:
+    Foo: "bar"
+  statusCode: 200
+
+- name: "Header Inclusion: POST Body - Pure - Foo header should not be aliased"
+  url: "http://%s:%s/v1/data"
+  body: '{ "input": { "method": "GET", "path": "/api/pure/header"} }'
+  header:
+    Foo: "bar"
   statusCode: 200


### PR DESCRIPTION
Map HTTP Request header into policy input. The header values will replace the request body, but only if set. Unset header will not overwrite the body with an empty value. 
Config Example: forward auth 
```yaml
global:
  input:
    header-mapping:
      - name: X-Forwarded-Method
        alias: method
      - name: X-Forwarded-URI
        alias: path
```

**NOTE**: This approach replaces the `/forward-auth` endpoint