### PR TITLE
fix(path-mapper): no longer panic on unmatched path

### DIFF
--- a/internal/pkg/api/rest-handler.go
+++ b/internal/pkg/api/rest-handler.go
@@ -102,6 +102,7 @@ func (proxy *restProxy) handleV1DataPost(w http.ResponseWriter, r *http.Request)
 
 	if err != nil {
 		proxy.handleError(ctx, w, wrapErrorInLoggingContext(err))
+		return
 	}
 
 	if decision.Allow {


### PR DESCRIPTION
Fix panics after url-mapper was unable to match path to policy package