### PR TITLE
fix(ast): relation detection adjustments for rego v1

### DIFF
--- a/cmd/kelon/kelon.go
+++ b/cmd/kelon/kelon.go
@@ -71,6 +71,8 @@ func main() {
 	setLogFormat()
 	// Set log level
 	setLogLevel()
+	// Log startup log with version
+	logging.LogForComponent("main").Infof("Kelon starting with version %s...", common.Version)
 
 	config := core.KelonConfiguration{
 		ConfigPath:               configurationPath,

--- a/examples/local/policies/mongo_example.rego
+++ b/examples/local/policies/mongo_example.rego
@@ -39,9 +39,9 @@ allow if {
 	input.path = ["api", "mongo", "apps", app_id]
 
 	# This query fires against collection -> app
-	some app
-	data.mongo.apps[app].stars == 5
-	app.id == app_id
+	some a in data.mongo.apps[_]
+	a.id == app_id
+	a.stars == 5
 }
 
 # Path: GET /api/mongo/apps/:app_id

--- a/examples/local/policies/mysql_example.rego
+++ b/examples/local/policies/mysql_example.rego
@@ -35,8 +35,8 @@ allow if {
 	input.method == "GET"
 	input.path = ["api", "mysql", "apps", app_id]
 
-	some app
-	data.mysql.apps[app].id == app_id
+	some app in data.mysql.apps[_]
+	app.id == app_id
 	absolute(app.stars) == 5
 }
 

--- a/examples/local/policies/pg_example.rego
+++ b/examples/local/policies/pg_example.rego
@@ -35,9 +35,9 @@ allow if {
 	input.method == "GET"
 	input.path = ["api", "pg", "apps", app_id]
 
-	some app
-	data.pg.pg_apps[app].id == app_id
-	absolute(app.stars) == 5
+	some a in data.pg.pg_apps[_]
+	a.id == app_id
+	absolute(a.stars) == 5
 }
 
 # Path: GET /api/pg/apps/:app_id

--- a/internal/pkg/translate/default-processor.go
+++ b/internal/pkg/translate/default-processor.go
@@ -33,7 +33,7 @@ func newAstProcessor(skipUnknown, validateMode bool) *astProcessor {
 	return processor
 }
 
-// Process --  See translate.AstTranslator.
+// Process -- See translate.AstTranslator.
 func (p *astProcessor) Process(_ context.Context, query ast.Body) (data.Node, error) {
 	p.link = make(map[string]any)
 	p.conjunctions = []data.Node{}
@@ -162,13 +162,13 @@ func (p *astProcessor) translateTerm(node *ast.Term) bool {
 		util.AppendToTopChecked("astProcessor", &p.operands, makeConstant(v.String()))
 		return true
 	case ast.Ref:
-		if len(v) == 3 {
+		if len(v) >= 3 {
 			entity := data.Entity{Value: normalizeString(v[1].Value.String())}
 			p.entities[entity.Value] = nil
 			if p.fromEntity == nil {
 				p.fromEntity = &entity
 			}
-			attribute := data.Attribute{Entity: entity, Name: normalizeString(v[2].Value.String())}
+			attribute := data.Attribute{Entity: entity, Name: normalizeString(v[len(v)-1].Value.String())}
 			util.AppendToTopChecked("astProcessor", &p.operands, data.Node(attribute))
 		}
 		return true


### PR DESCRIPTION
With some Rego V1 policies using a different syntax for retrieving an element from collections, the database relation detection had to be modified.

The problem was, that previously this syntax was used, which produced AST nodes of length 3, which was necessary to be detected as a reference.
```rego
some row
data.db.table[row]
```
This produced a Node similar to `["data", "db", "table"]`

But the following syntax produced a node of size 4, and therefore was not detected by the AST processor.
```rego
some row in data.db.table[_]
```
The produced Node looks similar to `["data", "db", "_local_123_", "table"]`, with a local variable name being injected before the table name.